### PR TITLE
Add more tests for cases where up and downcase expand to two or three chars

### DIFF
--- a/src/lowercase.rs
+++ b/src/lowercase.rs
@@ -119,6 +119,7 @@ impl<'a> FusedIterator for Lowercase<'a> {}
 mod tests {
     use alloc::vec::Vec;
     use bstr::ByteSlice;
+    use core::char;
 
     use super::Lowercase;
 
@@ -224,5 +225,26 @@ mod tests {
         let s = "İ".as_bytes();
         let iter = Lowercase::from(s);
         assert_eq!(iter.collect::<Vec<_>>(), [105_u8, 204, 135]);
+    }
+
+    #[test]
+    fn case_map_to_two_chars() {
+        let s = "İ".as_bytes();
+        let iter = Lowercase::from(s);
+        assert_eq!(iter.collect::<Vec<_>>(), "i\u{307}".as_bytes());
+    }
+
+    #[test]
+    fn case_map_to_three_chars() {
+        // there are no such characters
+        for ch in '\0'..char::MAX {
+            if ch.to_lowercase().count() == 3 {
+                panic!(
+                    "Expected no characters that downcase to three characters, found: '{}', which expands to: {:?}",
+                    ch,
+                    ch.to_lowercase().collect::<Vec<_>>()
+                );
+            }
+        }
     }
 }

--- a/src/uppercase.rs
+++ b/src/uppercase.rs
@@ -228,4 +228,38 @@ mod tests {
         let iter = Uppercase::from(s);
         assert_eq!(iter.collect::<Vec<_>>(), [73_u8, 204, 135]);
     }
+
+    #[test]
+    fn case_map_to_two_chars() {
+        let s = "և".as_bytes();
+        let iter = Uppercase::from(s);
+        assert_eq!(iter.collect::<Vec<_>>(), "ԵՒ".as_bytes());
+
+        let s = "ẙ".as_bytes();
+        let iter = Uppercase::from(s);
+        assert_eq!(iter.collect::<Vec<_>>(), "Y\u{30a}".as_bytes());
+
+        let s = "ᾂ".as_bytes();
+        let iter = Uppercase::from(s);
+        assert_eq!(iter.collect::<Vec<_>>(), "ἊΙ".as_bytes());
+
+        let s = "ﬗ".as_bytes();
+        let iter = Uppercase::from(s);
+        assert_eq!(iter.collect::<Vec<_>>(), "ՄԽ".as_bytes());
+    }
+
+    #[test]
+    fn case_map_to_three_chars() {
+        let s = "ﬃ".as_bytes();
+        let iter = Uppercase::from(s);
+        assert_eq!(iter.collect::<Vec<_>>(), b"FFI");
+
+        let s = "ὖ".as_bytes();
+        let iter = Uppercase::from(s);
+        assert_eq!(iter.collect::<Vec<_>>(), "Υ\u{313}\u{342}".as_bytes());
+
+        let s = "ῷ".as_bytes();
+        let iter = Uppercase::from(s);
+        assert_eq!(iter.collect::<Vec<_>>(), "Ω\u{342}Ι".as_bytes());
+    }
 }


### PR DESCRIPTION
These test cases are in preparation for `Capitalize` which mixes up and downcasing.