### PR TITLE
Make roe::uppercase and roe::lowercase const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ pub use uppercase::Uppercase;
 // This function treats the given slice as a conventionally UTF-8 string. UTF-8
 // byte sequences are converted to their Unicode lowercase equivalents. Invalid
 // UTF-8 byte sequences are yielded as is.
-pub fn lowercase(slice: &[u8]) -> Lowercase<'_> {
-    Lowercase::from(slice)
+pub const fn lowercase(slice: &[u8]) -> Lowercase<'_> {
+    Lowercase::with_slice(slice)
 }
 
 // Returns an iterator that yields a copy of the bytes in the given slice with
@@ -28,6 +28,6 @@ pub fn lowercase(slice: &[u8]) -> Lowercase<'_> {
 // This function treats the given slice as a conventionally UTF-8 string. UTF-8
 // byte sequences are converted to their Unicode uppercase equivalents. Invalid
 // UTF-8 byte sequences are yielded as is.
-pub fn uppercase(slice: &[u8]) -> Uppercase<'_> {
-    Uppercase::from(slice)
+pub const fn uppercase(slice: &[u8]) -> Uppercase<'_> {
+    Uppercase::with_slice(slice)
 }

--- a/src/lowercase.rs
+++ b/src/lowercase.rs
@@ -43,12 +43,7 @@ impl<'a> Default for Lowercase<'a> {
 
 impl<'a> From<&'a [u8]> for Lowercase<'a> {
     fn from(slice: &'a [u8]) -> Self {
-        Self {
-            slice,
-            next_bytes: [0; 4],
-            next_range: 0..0,
-            lowercase: None,
-        }
+        Self::with_slice(slice)
     }
 }
 
@@ -65,6 +60,30 @@ impl<'a> Lowercase<'a> {
     pub const fn new() -> Self {
         Self {
             slice: &[],
+            next_bytes: [0; 4],
+            next_range: 0..0,
+            lowercase: None,
+        }
+    }
+
+    /// Create a new lowercase iterator with the given byte slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use roe::Lowercase;
+    /// let mut lowercase = Lowercase::with_slice(b"abcXYZ");
+    /// assert_eq!(lowercase.next(), Some(b'a'));
+    /// assert_eq!(lowercase.next(), Some(b'b'));
+    /// assert_eq!(lowercase.next(), Some(b'c'));
+    /// assert_eq!(lowercase.next(), Some(b'x'));
+    /// assert_eq!(lowercase.next(), Some(b'y'));
+    /// assert_eq!(lowercase.next(), Some(b'z'));
+    /// assert_eq!(lowercase.next(), None);
+    /// ```
+    pub const fn with_slice(slice: &'a [u8]) -> Self {
+        Self {
+            slice,
             next_bytes: [0; 4],
             next_range: 0..0,
             lowercase: None,

--- a/src/uppercase.rs
+++ b/src/uppercase.rs
@@ -43,12 +43,7 @@ impl<'a> Default for Uppercase<'a> {
 
 impl<'a> From<&'a [u8]> for Uppercase<'a> {
     fn from(slice: &'a [u8]) -> Self {
-        Self {
-            slice,
-            next_bytes: [0; 4],
-            next_range: 0..0,
-            uppercase: None,
-        }
+        Self::with_slice(slice)
     }
 }
 
@@ -65,6 +60,30 @@ impl<'a> Uppercase<'a> {
     pub const fn new() -> Self {
         Self {
             slice: &[],
+            next_bytes: [0; 4],
+            next_range: 0..0,
+            uppercase: None,
+        }
+    }
+
+    /// Create a new uppercase iterator with the given byte slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use roe::Uppercase;
+    /// let mut uppercase = Uppercase::with_slice(b"abcXYZ");
+    /// assert_eq!(uppercase.next(), Some(b'A'));
+    /// assert_eq!(uppercase.next(), Some(b'B'));
+    /// assert_eq!(uppercase.next(), Some(b'C'));
+    /// assert_eq!(uppercase.next(), Some(b'X'));
+    /// assert_eq!(uppercase.next(), Some(b'Y'));
+    /// assert_eq!(uppercase.next(), Some(b'Z'));
+    /// assert_eq!(uppercase.next(), None);
+    /// ```
+    pub const fn with_slice(slice: &'a [u8]) -> Self {
+        Self {
+            slice,
             next_bytes: [0; 4],
             next_range: 0..0,
             uppercase: None,


### PR DESCRIPTION
Add two new `const fn` constructors for the underlying iterators:

- `Uppercase::with_slice`
- `Lowercase::with_slice`

Implement `From<&[u8]> for {Upper,Lower}case` with the `with_slice`
constructors.