### PR TITLE
Add in-place and to Vec ASCII case conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ version-sync = "0.9"
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds
 # that target. `boba` has the same API and code on all targets.
 targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,0 +1,14 @@
+mod lowercase;
+mod titlecase;
+mod uppercase;
+
+pub use lowercase::make_ascii_lowercase;
+pub use titlecase::make_ascii_titlecase;
+pub use uppercase::make_ascii_uppercase;
+
+#[cfg(feature = "alloc")]
+pub use lowercase::to_ascii_lowercase;
+#[cfg(feature = "alloc")]
+pub use titlecase::to_ascii_titlecase;
+#[cfg(feature = "alloc")]
+pub use uppercase::to_ascii_uppercase;

--- a/src/ascii/lowercase.rs
+++ b/src/ascii/lowercase.rs
@@ -1,0 +1,84 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// Converts the given slice to its ASCII lower case equivalent in-place.
+///
+/// ASCII letters 'A' to 'Z' are mapped to 'a' to 'z', but non-ASCII letters are
+/// unchanged.
+///
+/// This function can be used to implement [`String#downcase!`] for ASCII
+/// strings in Ruby.
+///
+/// To return a new lowercased value without modifying the existing one, use
+/// [`to_ascii_lowercase`].
+///
+/// See also [`<[u8]>::make_ascii_lowercase`][slice-primitive].
+///
+/// # Examples
+///
+/// ```
+/// # use roe::make_ascii_lowercase;
+/// let mut buf = *b"ABCxyz";
+/// make_ascii_lowercase(&mut buf);
+/// assert_eq!(buf, *b"abcxyz");
+///
+/// let mut buf = *b"1234%&*";
+/// make_ascii_lowercase(&mut buf);
+/// assert_eq!(buf, *b"1234%&*");
+/// ```
+///
+/// [`String#downcase!`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-downcase-21
+/// [slice-primitive]: https://doc.rust-lang.org/std/primitive.slice.html#method.make_ascii_lowercase
+#[inline]
+pub fn make_ascii_lowercase<T: AsMut<[u8]>>(mut slice: T) {
+    let slice = slice.as_mut();
+    slice.make_ascii_lowercase();
+}
+
+/// Returns a vector containing a copy of the given slice where each byte is
+/// mapped to its ASCII lower case equivalent.
+///
+/// ASCII letters 'A' to 'Z' are mapped to 'a' to 'z', but non-ASCII letters are
+/// unchanged.
+///
+/// This function can be used to implement [`String#downcase`] and
+/// [`Symbol#downcase`] for ASCII strings in Ruby.
+///
+/// To lowercase the value in-place, use [`make_ascii_lowercase`].
+///
+/// See also [`<[u8]>::to_ascii_lowercase`][slice-primitive].
+///
+/// # Examples
+///
+/// ```
+/// # use roe::to_ascii_lowercase;
+/// assert_eq!(to_ascii_lowercase("ABCxyz"), &b"abcxyz"[..]);
+/// assert_eq!(to_ascii_lowercase("1234%&*"), &b"1234%&*"[..]);
+/// ```
+///
+/// [`String#downcase`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-downcase
+/// [`Symbol#downcase`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-downcase
+/// [slice-primitive]: https://doc.rust-lang.org/std/primitive.slice.html#method.to_ascii_lowercase
+#[inline]
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn to_ascii_lowercase<T: AsRef<[u8]>>(slice: T) -> Vec<u8> {
+    let slice = slice.as_ref();
+    slice.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn make_ascii_lowercase_empty() {
+        let mut buf = *b"";
+        super::make_ascii_lowercase(&mut buf);
+        assert_eq!(buf, *b"");
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn to_ascii_lowercase_empty() {
+        assert_eq!(super::to_ascii_lowercase(""), b"");
+    }
+}

--- a/src/ascii/titlecase.rs
+++ b/src/ascii/titlecase.rs
@@ -1,0 +1,102 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// Converts the given slice to its ASCII title case equivalent in-place.
+///
+/// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z' in the first byte;
+/// subsequent bytes with ASCII letters 'A' to 'Z' are mapped to 'a' to 'z;
+/// non-ASCII letters are unchanged.
+///
+/// This function can be used to implement [`String#capitalize!`] for ASCII
+/// strings in Ruby.
+///
+/// To return a new titlecased value without modifying the existing one, use
+/// [`to_ascii_titlecase`].
+///
+/// # Examples
+///
+/// ```
+/// # use roe::make_ascii_titlecase;
+/// let mut buf = *b"ABCxyz";
+/// make_ascii_titlecase(&mut buf);
+/// assert_eq!(buf, *b"Abcxyz");
+///
+/// let mut buf = *b"1234%&*";
+/// make_ascii_titlecase(&mut buf);
+/// assert_eq!(buf, *b"1234%&*");
+///
+/// let mut buf = *b"ABC1234%&*";
+/// make_ascii_titlecase(&mut buf);
+/// assert_eq!(buf, *b"Abc1234%&*");
+///
+/// let mut buf = *b"1234%&*abcXYZ";
+/// make_ascii_titlecase(&mut buf);
+/// assert_eq!(buf, *b"1234%&*abcxyz");
+///
+/// let mut buf = *b"ABC, XYZ";
+/// make_ascii_titlecase(&mut buf);
+/// assert_eq!(buf, *b"Abc, xyz");
+/// ```
+///
+/// [`String#capitalize!`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-capitalize-21
+#[inline]
+pub fn make_ascii_titlecase<T: AsMut<[u8]>>(slice: &mut T) {
+    let slice = slice.as_mut();
+    if let Some((head, tail)) = slice.split_first_mut() {
+        head.make_ascii_uppercase();
+        tail.make_ascii_lowercase();
+    }
+}
+
+/// Returns a vector containing a copy of the given slice where each byte is
+/// mapped to its ASCII title case equivalent.
+///
+/// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z' in the first byte;
+/// subsequent bytes with ASCII letters 'A' to 'Z' are mapped to 'a' to 'z;
+/// non-ASCII letters are unchanged.
+///
+/// This function can be used to implement [`String#capitalize`] and
+/// [`Symbol#capitalize`] for ASCII strings in Ruby.
+///
+/// To titlecase the value in-place, use [`make_ascii_titlecase`].
+///
+/// # Examples
+///
+/// ```
+/// # use roe::to_ascii_titlecase;
+/// assert_eq!(to_ascii_titlecase("ABCxyz"), &b"Abcxyz"[..]);
+/// assert_eq!(to_ascii_titlecase("1234%&*"), &b"1234%&*"[..]);
+/// assert_eq!(to_ascii_titlecase("ABC1234%&*"), &b"Abc1234%&*"[..]);
+/// assert_eq!(to_ascii_titlecase("1234%&*abcXYZ"), &b"1234%&*abcxyz"[..]);
+/// assert_eq!(to_ascii_titlecase("ABC, XYZ"), &b"Abc, xyz"[..]);
+/// ```
+///
+/// [`String#capitalize`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-capitalize
+/// [`Symbol#capitalize`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-capitalize
+#[inline]
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn to_ascii_titlecase<T: AsRef<[u8]>>(slice: T) -> Vec<u8> {
+    let slice = slice.as_ref();
+    let mut titlecase = slice.to_ascii_lowercase();
+    if let Some(head) = titlecase.first_mut() {
+        head.make_ascii_uppercase();
+    }
+    titlecase
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn make_ascii_titlecase_empty() {
+        let mut buf = *b"";
+        super::make_ascii_titlecase(&mut buf);
+        assert_eq!(buf, *b"");
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn to_ascii_titlecase_empty() {
+        assert_eq!(super::to_ascii_titlecase(""), b"");
+    }
+}

--- a/src/ascii/uppercase.rs
+++ b/src/ascii/uppercase.rs
@@ -1,0 +1,84 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// Converts the given slice to its ASCII upper case equivalent in-place.
+///
+/// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z', but non-ASCII letters are
+/// unchanged.
+///
+/// This function can be used to implement [`String#upcase!`] for ASCII strings
+/// in Ruby.
+///
+/// To return a new uppercased value without modifying the existing one, use
+/// [`to_ascii_uppercase`].
+///
+/// See also [`<[u8]>::make_ascii_uppercase`][slice-primitive].
+///
+/// # Examples
+///
+/// ```
+/// # use roe::make_ascii_uppercase;
+/// let mut buf = *b"ABCxyz";
+/// make_ascii_uppercase(&mut buf);
+/// assert_eq!(buf, *b"ABCXYZ");
+///
+/// let mut buf = *b"1234%&*";
+/// make_ascii_uppercase(&mut buf);
+/// assert_eq!(buf, *b"1234%&*");
+/// ```
+///
+/// [`String#upcase!`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-upcase-21
+/// [slice-primitive]: https://doc.rust-lang.org/std/primitive.u8.html#method.make_ascii_uppercase
+#[inline]
+pub fn make_ascii_uppercase<T: AsMut<[u8]>>(slice: &mut T) {
+    let slice = slice.as_mut();
+    slice.make_ascii_uppercase();
+}
+
+/// Returns a vector containing a copy of the given slice where each byte is
+/// mapped to its ASCII upper case equivalent.
+///
+/// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z', but non-ASCII letters are
+/// unchanged.
+///
+/// This function can be used to implement [`String#upcase`] and
+/// [`Symbol#upcase`] for ASCII strings in Ruby.
+///
+/// To uppercase the value in-place, use [`make_ascii_uppercase`].
+///
+/// See also [`<[u8]>::to_ascii_uppercase`][slice-primitive].
+///
+/// # Examples
+///
+/// ```
+/// # use roe::to_ascii_uppercase;
+/// assert_eq!(to_ascii_uppercase("ABCxyz"), &b"ABCXYZ"[..]);
+/// assert_eq!(to_ascii_uppercase("1234%&*"), &b"1234%&*"[..]);
+/// ```
+///
+/// [`String#upcase`]: https://ruby-doc.org/core-2.6.3/String.html#method-i-upcase
+/// [`Symbol#upcase`]: https://ruby-doc.org/core-2.6.3/Symbol.html#method-i-upcase
+/// [slice-primitive]: https://doc.rust-lang.org/std/primitive.slice.html#method.to_ascii_uppercase
+#[inline]
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn to_ascii_uppercase<T: AsRef<[u8]>>(slice: T) -> Vec<u8> {
+    let slice = slice.as_ref();
+    slice.to_ascii_uppercase()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn make_ascii_uppercase_empty() {
+        let mut buf = *b"";
+        super::make_ascii_uppercase(&mut buf);
+        assert_eq!(buf, *b"");
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn to_ascii_uppercase_empty() {
+        assert_eq!(super::to_ascii_uppercase(""), b"");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
 #![no_std]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
 #[cfg(any(feature = "alloc", test))]
 extern crate alloc;
@@ -10,9 +16,13 @@ use core::convert::{TryFrom, TryInto};
 use core::fmt;
 use core::str::FromStr;
 
+mod ascii;
 mod lowercase;
 mod uppercase;
 
+pub use ascii::{make_ascii_lowercase, make_ascii_titlecase, make_ascii_uppercase};
+#[cfg(feature = "alloc")]
+pub use ascii::{to_ascii_lowercase, to_ascii_titlecase, to_ascii_uppercase};
 pub use lowercase::Lowercase;
 pub use uppercase::Uppercase;
 


### PR DESCRIPTION
- `make_ascii_lowercase`
- `to_ascii_lowercase`
- `make_ascii_titlecase`
- `to_ascii_titlecase`
- `make_ascii_uppercase`
- `to_ascii_uppercase`

The `to_` variants require the `alloc` Cargo feature.