### PR TITLE
Use proper AsMut generic bound on make_ascii_lowercase

### DIFF
--- a/src/ascii/lowercase.rs
+++ b/src/ascii/lowercase.rs
@@ -31,7 +31,7 @@ use alloc::vec::Vec;
 /// [slice-primitive]: https://doc.rust-lang.org/std/primitive.slice.html#method.make_ascii_lowercase
 #[inline]
 #[allow(clippy::module_name_repetitions)]
-pub fn make_ascii_lowercase<T: AsMut<[u8]>>(mut slice: T) {
+pub fn make_ascii_lowercase<T: AsMut<[u8]>>(slice: &mut T) {
     let slice = slice.as_mut();
     slice.make_ascii_lowercase();
 }


### PR DESCRIPTION
https://doc.rust-lang.org/std/convert/trait.AsMut.html#generic-implementations

found this while browsing `roe` rustdoc sources on GitHub Pages.