### PR TITLE
Remove Zlib as an allowed license from cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,6 @@ ignore = []
 unlicensed = "deny"
 allow = [
   "MIT",
-  "Zlib",
 ]
 deny = []
 copyleft = "deny"


### PR DESCRIPTION
TinyVec relicensed to include an MIT option in Lokathor/tinyvec#81.