### PR TITLE
Prepare for v0.0.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roe"
-version = "0.0.2" # remember to set `html_root_url` in `src/lib.rs`.
+version = "0.0.3" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-roe = "0.0.2"
+roe = "0.0.3"
 ```
 
 Then convert case like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //! [conventionally UTF-8 binary strings]: https://docs.rs/bstr/0.2.*/bstr/#when-should-i-use-byte-strings
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/roe/0.0.2")]
+#![doc(html_root_url = "https://docs.rs/roe/0.0.3")]
 
 #[cfg(any(feature = "alloc", test))]
 extern crate alloc;


### PR DESCRIPTION
Release `roe` 0.0.3.

[`roe` is published on crates.io](https://crates.io/crates/roe/0.0.3).

## Status

`roe` is currently a work in process. Many APIs are not implemented or partially implemented and may panic. No new APIs have been added since v0.0.2.

## Packaging improvements

- Use proper `AsMut` generic bound on `make_ascii_lowercase`. https://github.com/artichoke/roe/pull/22
- Fix typo'd clippy allow. https://github.com/artichoke/roe/pull/40
- Update version-sync to 0.9.3 and trim some deps from Cargo.lock. https://github.com/artichoke/roe/pull/64
- Fix `clippy::manual_assert` lint violations in Rust 1.58. https://github.com/artichoke/roe/pull/70
- Fix up docs so they build with no default features. https://github.com/artichoke/roe/pull/97
