### PR TITLE
Update bstr to 1.0, prepare for 0.0.4 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roe"
-version = "0.0.3" # remember to set `html_root_url` in `src/lib.rs`.
+version = "0.0.4" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"
@@ -23,8 +23,7 @@ std = ["alloc"]
 alloc = []
 
 [dependencies]
-# `no_std` mode was fixed in https://github.com/BurntSushi/bstr/commit/83e8f27e
-bstr = { version = "0.2.4", default-features = false }
+bstr = { version = "1.0.1", default-features = false }
 
 [dev-dependencies]
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-roe = "0.0.3"
+roe = "0.0.4"
 ```
 
 Then convert case like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //! [conventionally UTF-8 binary strings]: https://docs.rs/bstr/0.2.*/bstr/#when-should-i-use-byte-strings
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/roe/0.0.3")]
+#![doc(html_root_url = "https://docs.rs/roe/0.0.4")]
 
 #[cfg(any(feature = "alloc", test))]
 extern crate alloc;


### PR DESCRIPTION
Release `roe` 0.0.4.

[`roe` is published on crates.io](https://crates.io/crates/roe/0.0.4).

## Status

`roe` is currently a work in process. Many APIs are not implemented or partially implemented and may panic. No new APIs have been added since v0.0.3.

## Improvements

- Implement code coverage testing. https://github.com/artichoke/roe/pull/100
- Move readme doctest module at the end of the file. https://github.com/artichoke/roe/pull/101
- Update bstr to 1.0. https://github.com/artichoke/roe/pull/112