### PR TITLE
Add no-std, no-alloc crates.io category metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roe"
-version = "0.0.4" # remember to set `html_root_url` in `src/lib.rs`.
+version = "0.0.5" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/roe"
 homepage = "https://github.com/artichoke/roe"
 description = "Unicode case conversion"
 keywords = ["capitalize", "case", "lowercase", "unicode", "uppercase"]
-categories = ["encoding", "internationalization", "no-std", "text-processing"]
+categories = ["encoding", "internationalization", "no-std", "no-std::no-alloc", "text-processing"]
 include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-roe = "0.0.4"
+roe = "0.0.5"
 ```
 
 Then convert case like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //! [conventionally UTF-8 binary strings]: https://docs.rs/bstr/0.2.*/bstr/#when-should-i-use-byte-strings
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/roe/0.0.4")]
+#![doc(html_root_url = "https://docs.rs/roe/0.0.5")]
 
 #[cfg(any(feature = "alloc", test))]
 extern crate alloc;


### PR DESCRIPTION
Prepare for v0.0.5 release.