### PR TITLE
impl default for all iterator types

### DIFF
--- a/src/lowercase/mod.rs
+++ b/src/lowercase/mod.rs
@@ -27,6 +27,12 @@ pub struct Lowercase<'a> {
     iter: Inner<'a>,
 }
 
+impl<'a> Default for Lowercase<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> Lowercase<'a> {
     /// Create a new, empty lowercase iterator.
     ///

--- a/src/lowercase/mod.rs
+++ b/src/lowercase/mod.rs
@@ -172,6 +172,9 @@ mod tests {
         let iter = Lowercase::new();
         assert_eq!(iter.collect::<Vec<_>>().as_bstr(), b"".as_bstr());
 
+        let iter = Lowercase::default();
+        assert_eq!(iter.collect::<Vec<_>>().as_bstr(), b"".as_bstr());
+
         let iter = Lowercase::with_slice(b"");
         assert_eq!(iter.collect::<Vec<_>>().as_bstr(), b"".as_bstr());
 
@@ -182,6 +185,8 @@ mod tests {
     #[test]
     fn size_hint() {
         assert_eq!(Lowercase::new().size_hint(), (0, Some(0)));
+        assert_eq!(Lowercase::default().size_hint(), (0, Some(0)));
+        assert_eq!(Lowercase::with_slice(b"").size_hint(), (0, Some(0)));
 
         assert_eq!(Lowercase::with_slice(b"abc, xyz").size_hint(), (8, Some(8)));
         assert_eq!(
@@ -240,6 +245,8 @@ mod tests {
     #[test]
     fn count() {
         assert_eq!(Lowercase::new().count(), 0);
+        assert_eq!(Lowercase::default().count(), 0);
+        assert_eq!(Lowercase::with_slice(b"").count(), 0);
 
         assert_eq!(Lowercase::with_slice(b"abc, xyz").count(), 8);
         assert_eq!(Lowercase::with_slice(b"abc, \xFF\xFE, xyz").count(), 12);

--- a/src/titlecase/mod.rs
+++ b/src/titlecase/mod.rs
@@ -27,6 +27,12 @@ pub struct Titlecase<'a> {
     iter: Inner<'a>,
 }
 
+impl<'a> Default for Titlecase<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> Titlecase<'a> {
     /// Create a new, empty titlecase iterator.
     ///

--- a/src/titlecase/mod.rs
+++ b/src/titlecase/mod.rs
@@ -176,6 +176,9 @@ mod tests {
         let iter = Titlecase::new();
         assert_eq!(iter.collect::<Vec<_>>().as_bstr(), b"".as_bstr());
 
+        let iter = Titlecase::default();
+        assert_eq!(iter.collect::<Vec<_>>().as_bstr(), b"".as_bstr());
+
         let iter = Titlecase::with_slice(b"");
         assert_eq!(iter.collect::<Vec<_>>().as_bstr(), b"".as_bstr());
 
@@ -186,6 +189,8 @@ mod tests {
     #[test]
     fn size_hint() {
         assert_eq!(Titlecase::new().size_hint(), (0, Some(0)));
+        assert_eq!(Titlecase::default().size_hint(), (0, Some(0)));
+        assert_eq!(Titlecase::with_slice(b"").size_hint(), (0, Some(0)));
 
         assert_eq!(Titlecase::with_slice(b"abc, xyz").size_hint(), (8, Some(8)));
         assert_eq!(
@@ -244,6 +249,8 @@ mod tests {
     #[test]
     fn count() {
         assert_eq!(Titlecase::new().count(), 0);
+        assert_eq!(Titlecase::default().count(), 0);
+        assert_eq!(Titlecase::with_slice(b"").count(), 0);
 
         assert_eq!(Titlecase::with_slice(b"abc, xyz").count(), 8);
         assert_eq!(Titlecase::with_slice(b"abc, \xFF\xFE, xyz").count(), 12);

--- a/src/uppercase/mod.rs
+++ b/src/uppercase/mod.rs
@@ -172,6 +172,9 @@ mod tests {
         let iter = Uppercase::new();
         assert_eq!(iter.collect::<Vec<_>>().as_bstr(), b"".as_bstr());
 
+        let iter = Uppercase::default();
+        assert_eq!(iter.collect::<Vec<_>>().as_bstr(), b"".as_bstr());
+
         let iter = Uppercase::with_slice(b"");
         assert_eq!(iter.collect::<Vec<_>>().as_bstr(), b"".as_bstr());
 
@@ -182,6 +185,8 @@ mod tests {
     #[test]
     fn size_hint() {
         assert_eq!(Uppercase::new().size_hint(), (0, Some(0)));
+        assert_eq!(Uppercase::default().size_hint(), (0, Some(0)));
+        assert_eq!(Uppercase::with_slice(b"").size_hint(), (0, Some(0)));
 
         assert_eq!(Uppercase::with_slice(b"abc, xyz").size_hint(), (8, Some(8)));
         assert_eq!(
@@ -240,6 +245,8 @@ mod tests {
     #[test]
     fn count() {
         assert_eq!(Uppercase::new().count(), 0);
+        assert_eq!(Uppercase::default().count(), 0);
+        assert_eq!(Uppercase::with_slice(b"").count(), 0);
 
         assert_eq!(Uppercase::with_slice(b"abc, xyz").count(), 8);
         assert_eq!(Uppercase::with_slice(b"abc, \xFF\xFE, xyz").count(), 12);

--- a/src/uppercase/mod.rs
+++ b/src/uppercase/mod.rs
@@ -27,6 +27,12 @@ pub struct Uppercase<'a> {
     iter: Inner<'a>,
 }
 
+impl<'a> Default for Uppercase<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> Uppercase<'a> {
     /// Create a new, empty uppercase iterator.
     ///


### PR DESCRIPTION
Addresses clippy lint `clippy::new_without_default`